### PR TITLE
Fix and improve default CI configuration

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,11 +1,13 @@
-image: gitlab-registry.cern.ch/lhcb-docker/analysis-ci/cc7:latest
+default:
+   image: gitlab-registry.cern.ch/lhcb-docker/analysis-ci/cc7:latest
+   tags:
+      - cvmfs
+   before_script:
+      - source /cvmfs/sft.cern.ch/lcg/views/setupViews.sh LCG_100 x86_64-centos7-gcc10-opt
 
 stages:
    - build
    - test
-
-before_script:
-   - source /cvmfs/sft.cern.ch/lcg/views/setupViews.sh LCG_100 x86_64-centos7-gcc10-opt
 
 build:
    stage: build


### PR DESCRIPTION
Set the tags correctly in the GitLab configuration file so we can access CVMFS in the GitLab runners